### PR TITLE
Landsat Workflow Automation

### DIFF
--- a/codeflare_helpers/landsat_workflow/landsat_workflow.md
+++ b/codeflare_helpers/landsat_workflow/landsat_workflow.md
@@ -1,0 +1,6 @@
+## Run step 4
+=== "Run step 4"
+    some description
+    ```shell
+    bash ./CodeFlare-Extractors/codeflare_helpers/landsat_workflow/step_4_copy_results_hpc_to_clowder.sh
+    ```

--- a/codeflare_helpers/landsat_workflow/step_4_copy_results_hpc_to_clowder.sh
+++ b/codeflare_helpers/landsat_workflow/step_4_copy_results_hpc_to_clowder.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# ssh into remote client and execute commands remotely
+# ssh kastanday@dt-login02.delta.ncsa.illinois.edu 'bash -s' << EOF
+ssh kastanday@dt-login02.delta.ncsa.illinois.edu 'zsh -s' << EOF
+
+source ~/.zshrc
+
+conda activate landsattrend2
+
+# Setup Ingmar's github 
+mkdir -p ~/codeflare_utils/landsat_workflow
+cd ~/codeflare_utils/landsat_workflow
+
+if [ ! -d "landsattrend" ]; then
+  git clone git@github.com:initze/landsattrend.git
+fi
+
+cd landsattrend
+git checkout dev4Clowder_Ingmar_deployed_delta
+
+# Run code
+bash ~/codeflare_utils/landsat_workflow/landsattrend/import_export/upload_region_output.sh https://pdg.clowderframework.org/ 981ab4c8-7d22-418d-93a2-b47019c2f583 ALASKA /scratch/bbou/toddn/landsat-delta/landsattrend/process 649232e2e4b00aa1838f0fc2
+echo "'upload_region_output.sh' completed, exiting."
+
+EOF

--- a/index.md
+++ b/index.md
@@ -158,6 +158,15 @@ fi
     # Launch script (docker compose up)
     bash ./CodeFlare-Extractors/codeflare_helpers/launch_clowder.sh
     ```
+=== "🛰️  Run Landsat Analysis Workflow"
+    Google Cloud Storage → Clowder → HPC Jobs → Results to Clowder
+
+    ```shell
+    bash ./CodeFlare-Extractors/codeflare_helpers/launch_clowder.sh
+    ```
+
+    :import{CodeFlare-Extractors/codeflare_helpers/landsat_workflow/landsat_workflow.md}
+
 
 === "↔️  Move in and out of Clowder"
     You can import data from anywhere, and export data to anywhere. Just select a source, then a destination. First select your source files, then your destination location.


### PR DESCRIPTION
See the Landsat repo for the corresponding PR enabling these changes: https://github.com/initze/landsattrend/pull/17 

## Landsat full pipeline to automate
1. Google Earth to Google Cloud Storage. Can take days, not great observability.
Gives list of files, but not all files show up in storage bucket because irrelevant ones are filtered out (like all-water images).
2. GCS to HPC. Pretty quick.
3. HPC Jobs
  a. Generate SLURM files: `generate_slurm_for_site.py`
  b. Runtime: 2-3 hours per zone.
4. Upload to Clowder
  a. Input data to Clowder 
  b. ✅ Results to Clowder `upload_region_output.sh`

